### PR TITLE
Refactor, Fix: 정규식 수정, 예문 프롬프트 수정

### DIFF
--- a/app/src/main/java/com/example/english_personal_training/WordListAdapter.kt
+++ b/app/src/main/java/com/example/english_personal_training/WordListAdapter.kt
@@ -97,7 +97,7 @@ class WordListAdapter : RecyclerView.Adapter<WordListAdapter.WordListViewHolder>
         if (loadingMap[word.word] == true) return
 
         // Check if the word and meaning are valid (simple validation)
-        if (!word.word.matches(Regex("^[a-zA-Z]+$")) || !word.meaning.matches(Regex("^[가-힣]+$"))) {
+        if (!word.word.matches(Regex("^[a-zA-ZÀ-ÿ\\s,-]+$")) || !word.meaning.matches(Regex("^[가-힣,~;\\s]+\$"))) {
             CoroutineScope(Dispatchers.Main).launch {
                 examplesTextView.text = "Failed to load example."
                 examplesTextView.visibility = View.VISIBLE
@@ -123,10 +123,14 @@ conditions:
 memorizable
 easy to speak
 Make sure the sentence is clear and grammatically correct. 
+You should refer to the official English dictionary.
+Find a sentence with as few words as possible
+The answer must include the 'literal meaning' in korean.
 Bold the word '${word.word}' in the English sentence using HTML <b> tags.
 한글 문법을 철저히 지키세요!
 [important]
-suggest EASY sentence.
+Suggest EASY sentence.
+Answer should be two lines.
 <a example sentence in korean> should be Natural sentences in Korean
 [answer form]
 English: <example sentence><newline>Korean: <a example sentence in korean>.

--- a/app/src/main/java/com/example/english_personal_training/WordListAdapter.kt
+++ b/app/src/main/java/com/example/english_personal_training/WordListAdapter.kt
@@ -113,17 +113,25 @@ class WordListAdapter : RecyclerView.Adapter<WordListAdapter.WordListViewHolder>
             val request = OpenAIRequest(
                 model = "gpt-4-turbo",
                 messages = listOf(
-                    Message(role = "system", content = "You are a helpful assistant."),
-                    Message(role = "user", content = """
-                        Provide an example sentence for the word '${word.word}' in English and its Korean translation. 
-                        The sentence should clearly demonstrate the meaning '${word.meaning}' of the word '${word.word}'. 
-                        Make sure the sentence is clear and grammatically correct. 
-                        Return the result in the format: 
-                        'English: <example sentence><newline>Korean: <translation>'.
-                        Make sure the Korean translation is natural and grammatically correct. 
-                        Bold the word '${word.word}' in the English sentence using HTML <b> tags.
+                    Message(role = "system", content = "You are a helpful, fastest answering English teacher teaching Korean students in English."),
+                    Message(role = "user", content =
+                    """
+${word.word}
+task: Write a appropriate english example sentence.
+conditions: 
+<a example sentence in korean> contain the literal korean meaning of  provided word
+memorizable
+easy to speak
+Make sure the sentence is clear and grammatically correct. 
+Bold the word '${word.word}' in the English sentence using HTML <b> tags.
+한글 문법을 철저히 지키세요!
+[important]
+suggest EASY sentence.
+<a example sentence in korean> should be Natural sentences in Korean
+[answer form]
+English: <example sentence><newline>Korean: <a example sentence in korean>.
                     """.trimIndent())
-                )
+                ),
             )
 
             try {

--- a/app/src/main/res/layout/fragment_db.xml
+++ b/app/src/main/res/layout/fragment_db.xml
@@ -153,16 +153,22 @@
             android:background="@drawable/word_btn"
             />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerView"
+        <ScrollView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="1sp"
-            android:layout_marginEnd="8dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/addButton"
-            app:layout_constraintVertical_bias="0.139"
-            android:fontFamily="@font/pretendard_light"
-            />
+            app:layout_constraintTop_toBottomOf="@id/addButton"
+            tools:ignore="MissingConstraints"
+            tools:layout_editor_absoluteX="0dp">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recyclerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginTop="1sp"
+                    android:layout_marginEnd="8dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/addButton"
+                    app:layout_constraintVertical_bias="0.139" />
+        </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_db.xml
+++ b/app/src/main/res/layout/fragment_db.xml
@@ -167,6 +167,7 @@
                     android:layout_marginStart="8dp"
                     android:layout_marginTop="1sp"
                     android:layout_marginEnd="8dp"
+                    android:paddingBottom="200dp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/addButton"
                     app:layout_constraintVertical_bias="0.139" />


### PR DESCRIPTION
- Refactor: GPT API가 적절한 조건과 형식의 예문 응답을 내놓도록 프롬프트 수정
  - 응답이 두줄이어야 하며, 한국어 뜻의 문법 지키고, 되도록 이해하기 쉽게 짧은 문장으로 내놓도록 수정
- Refactor: 숙어 입력에 대한 예문도 작성하도록 정규식 필터링 수정
- Fix: 단어목록 확인시 바텀네비게이션 바에 가려져서 단어목록이 안보이는 경우가 발생 ⇨ recyclerView의 paddingBottom을 지정하여 바텀 네비게이션에 가려지지 않도록 수정