### PR TITLE
Fix, Feat: Wordlist item 하나만 선택 수정 가능, 전체삭제 실수눌림 방지

### DIFF
--- a/app/src/main/java/com/example/english_personal_training/FastItemAnimator.kt
+++ b/app/src/main/java/com/example/english_personal_training/FastItemAnimator.kt
@@ -1,0 +1,13 @@
+package com.example.english_personal_training
+import androidx.recyclerview.widget.DefaultItemAnimator
+
+class FastItemAnimator : DefaultItemAnimator() {
+
+    init {
+        // Set the animation durations to be faster
+        addDuration = 0
+        removeDuration = 0
+        moveDuration = 0
+        changeDuration = 0
+    }
+}

--- a/app/src/main/java/com/example/english_personal_training/WordSetAdapter.kt
+++ b/app/src/main/java/com/example/english_personal_training/WordSetAdapter.kt
@@ -11,6 +11,7 @@ import com.example.english_personal_training.data.ItemViewModel
 class WordSetAdapter(private var itemList: MutableList<Item>) : RecyclerView.Adapter<WordSetAdapter.ItemViewHolder>() {
 
     private lateinit var itemViewModel: ItemViewModel
+    private var editingPosition: Int? = null
 
     init {
         setHasStableIds(true)
@@ -26,12 +27,23 @@ class WordSetAdapter(private var itemList: MutableList<Item>) : RecyclerView.Ada
     }
 
     override fun onBindViewHolder(holder: ItemViewHolder, position: Int) {
-        holder.bind(itemList[position])
+        holder.bind(itemList[position], position == editingPosition)
+
         holder.itemView.setOnClickListener {
-            holder.toggleEditMode()
+            if (editingPosition == position) {
+                holder.toggleEditMode()
+                editingPosition = null
+            } else {
+                val previousEditingPosition = editingPosition
+                editingPosition = position
+                notifyItemChanged(previousEditingPosition ?: -1)
+                notifyItemChanged(position)
+            }
         }
+
         holder.binding.doneButton.setOnClickListener {
             holder.toggleEditMode()
+            editingPosition = null
             // 수정된 내용을 TextView에 반영
             holder.tagTextView.text = holder.tagEditTextView.text
             holder.wordTextView.text = holder.wordEditTextView.text
@@ -51,7 +63,6 @@ class WordSetAdapter(private var itemList: MutableList<Item>) : RecyclerView.Ada
             val currentItem = itemList[position]
             itemViewModel.delete(currentItem)
         }
-
     }
 
     override fun getItemCount(): Int = itemList.size
@@ -70,7 +81,7 @@ class WordSetAdapter(private var itemList: MutableList<Item>) : RecyclerView.Ada
         val meaningEditTextView = binding.meaningEditTextView
         val doneButton = binding.doneButton
 
-        fun bind(item: Item) {
+        fun bind(item: Item, isEditMode: Boolean) {
             // TextView에 텍스트 설정
             tagTextView.text = item.tag
             wordTextView.text = item.word
@@ -81,14 +92,14 @@ class WordSetAdapter(private var itemList: MutableList<Item>) : RecyclerView.Ada
             wordEditTextView.setText(item.word)
             meaningEditTextView.setText(item.meaning)
 
-            // 초기에는 EditText를 보이지 않도록 설정
-            tagTextView.visibility = View.VISIBLE
-            wordTextView.visibility = View.VISIBLE
-            meaningTextView.visibility = View.VISIBLE
-            tagEditTextView.visibility = View.GONE
-            wordEditTextView.visibility = View.GONE
-            meaningEditTextView.visibility = View.GONE
-            doneButton.visibility = View.GONE
+            // EditText를 보이거나 숨기도록 설정
+            tagTextView.visibility = if (isEditMode) View.GONE else View.VISIBLE
+            wordTextView.visibility = if (isEditMode) View.GONE else View.VISIBLE
+            meaningTextView.visibility = if (isEditMode) View.GONE else View.VISIBLE
+            tagEditTextView.visibility = if (isEditMode) View.VISIBLE else View.GONE
+            wordEditTextView.visibility = if (isEditMode) View.VISIBLE else View.GONE
+            meaningEditTextView.visibility = if (isEditMode) View.VISIBLE else View.GONE
+            doneButton.visibility = if (isEditMode) View.VISIBLE else View.GONE
         }
 
         fun toggleEditMode() {
@@ -110,4 +121,3 @@ class WordSetAdapter(private var itemList: MutableList<Item>) : RecyclerView.Ada
         notifyDataSetChanged()
     }
 }
-

--- a/app/src/main/java/com/example/english_personal_training/WordSetFragment.kt
+++ b/app/src/main/java/com/example/english_personal_training/WordSetFragment.kt
@@ -1,3 +1,4 @@
+import android.app.AlertDialog
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
@@ -95,17 +96,29 @@ class WordSetFragment : Fragment() {
 
         // 전체삭제 버튼 listener 처리
         binding.buttonDeleteAll.setOnClickListener {
-            itemViewModel.deleteAll()
-            // deleteAll 호출 후 즉시 LiveData를 관찰하여 RecyclerView를 업데이트
-            itemViewModel.allItems.observe(viewLifecycleOwner, { items ->
-                items?.let { adapter.updateItems(it) }
-            })
+            // 다이얼로그를 표시하여 사용자에게 확인을 받음
+            showConfirmationDialog()
         }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun showConfirmationDialog() {
+        val builder = AlertDialog.Builder(requireContext())
+        builder.setTitle("전체 삭제")
+            .setMessage("정말 전체 삭제하시겠습니까?\n모든 단어가 삭제됩니다.")
+            .setPositiveButton("YES") { dialog, _ ->
+                // "YES"를 누르면 전체 삭제 수행
+                itemViewModel.deleteAll()
+                dialog.dismiss()
+            }
+            .setNegativeButton("NO") { dialog, _ ->
+                dialog.dismiss()
+            }
+            .show()
     }
 
     private fun parseCsv(context: Context, uri: Uri): List<Item> {

--- a/app/src/main/java/com/example/english_personal_training/WordSetFragment.kt
+++ b/app/src/main/java/com/example/english_personal_training/WordSetFragment.kt
@@ -1,4 +1,3 @@
-
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
@@ -9,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.english_personal_training.FastItemAnimator
 import com.example.english_personal_training.R
 import com.example.english_personal_training.WordSetAdapter
 import com.example.english_personal_training.data.Item
@@ -47,6 +47,9 @@ class WordSetFragment : Fragment() {
         binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
         adapter = WordSetAdapter(mutableListOf())
         binding.recyclerView.adapter = adapter
+
+        // Set the custom item animator
+        binding.recyclerView.itemAnimator = FastItemAnimator()
 
         // ViewModelProvider로 itemViewModel 초기화
         val factory = ItemViewModelFactory(requireActivity().application)


### PR DESCRIPTION
- Wordlist의 item을 하나만 선택하여 수정 가능하게 변경하였습니다.
-  전체삭제 실수눌림을 방지하기 위해 다이얼로그로 전체삭제할 것이냐고 삭제 의향을 재확인하도록 하였습니다.